### PR TITLE
Feature/auth jwt

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,6 @@ app.set('port', PORT);
 
 app.use(cors(corsOptions));
 app.use(express.json());
-app.use('/uploads', express.static('uploads'));
 app.use('/api/v1/contents', contents);
 app.use('/api/v1/results', results);
 app.use('/api/oauth2/kakao', kakaoLogin);

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,8 +1,8 @@
-import mongoose, { Document } from 'mongoose';
-
 export * from './content';
 export * from './result';
 export * from './login';
+
+import mongoose, { Document } from 'mongoose';
 
 export interface IBase extends Document {
   contentId: mongoose.Types.ObjectId;

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,50 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { SECRET_KEY } from '../constants';
+import { IUser } from '../interfaces/user';
+import UserModel from '../schemas/User';
+
+const authMiddleware = async (req: Request, res: Response, next: NextFunction) => {
+  const authHeader = req.headers.authorization;
+
+  try {
+    if (!authHeader) {
+      return res.status(401).send({ message: '엑세스 토큰을 입력해 주세요.' });
+    }
+
+    const token = authHeader.split(' ')[1];
+
+    if (!token) {
+      return res.status(401).send({ message: '엑세스 토큰을 입력해 주세요.' });
+    }
+
+    const decoded = jwt.verify(token, SECRET_KEY) as JwtPayload;
+
+    const userId = decoded.userId;
+
+    if (!userId) {
+      return res.status(403).send({ message: '유효하지 않은 토큰입니다.' });
+    }
+
+    const user = await UserModel.findOne<IUser>({ kakaoId: userId }).exec();
+
+    if (!user) {
+      return res.status(404).send({ message: '유저를 찾을 수 없습니다.' });
+    }
+
+    req.user = user;
+
+    next();
+  } catch (error) {
+    if (error instanceof jwt.TokenExpiredError) {
+      return res.status(403).send({ message: '엑세스 토큰이 만료되었습니다.' });
+    } else if (error instanceof jwt.JsonWebTokenError) {
+      return res.status(403).send({ message: '유효하지 않은 토큰입니다.' });
+    }
+
+    console.error('JWT verification error:', error);
+    return res.status(500).send({ message: '서버 오류입니다.' });
+  }
+};
+
+export default authMiddleware;

--- a/src/routes/kakaoLogin.ts
+++ b/src/routes/kakaoLogin.ts
@@ -5,7 +5,7 @@ import UserModel from '../schemas/User';
 import LoginModel from '../schemas/Login';
 import jwt from 'jsonwebtoken';
 import { IUser } from '../interfaces/user';
-import { AuthToken, Payload, userInfoResponse } from '../types/login';
+import { AuthToken, Payload, UserInfoResponse } from '../types/auth';
 
 const router = express.Router();
 
@@ -34,7 +34,7 @@ router.get('/', async (req: Request<{}, {}, {}, { code: string }>, res: Response
 
     const accessToken = authToken.data.access_token;
 
-    const userInfoResponse = await axios.post<userInfoResponse>(
+    const userInfoResponse = await axios.post<UserInfoResponse>(
       'https://kapi.kakao.com/v2/user/me',
       {},
       {
@@ -47,7 +47,7 @@ router.get('/', async (req: Request<{}, {}, {}, { code: string }>, res: Response
 
     const userInfoData = userInfoResponse.data;
 
-    let user = await UserModel.findOne<IUser>({ kakaoId: userInfoData });
+    let user = await UserModel.findOne<IUser>({ kakaoId: userInfoData.id });
 
     if (user) {
       user.name = userInfoData.kakao_account.profile.nickname;
@@ -72,7 +72,7 @@ router.get('/', async (req: Request<{}, {}, {}, { code: string }>, res: Response
     };
 
     const payload: Payload = {
-      userId: user._id,
+      userId: user.kakaoId,
       role: user.role,
     };
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -6,7 +6,7 @@ export type AuthToken = {
   refresh_token_expires_in: string; // 리프레시 토큰 만료 시간(초)
 };
 
-export type userInfoResponse = {
+export type UserInfoResponse = {
   id: number;
   connected_at: Date;
   kakao_account: {
@@ -18,6 +18,6 @@ export type userInfoResponse = {
 };
 
 export type Payload = {
-  userId: string | unknown;
+  userId: number;
   role: string;
 };

--- a/src/types/express/index.d.ts
+++ b/src/types/express/index.d.ts
@@ -1,0 +1,9 @@
+import { IUser } from '../../interfaces/user';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: IUser;
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,3 @@
+export * from './auth';
+
 export type ContentType = 'MBTI';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,3 @@
+export * from './upload';
+
 export const createdDate = () => Math.floor(Date.now() / 1000);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "outDir": "dist",
+    "outDir": "./dist",
     "baseUrl": "./src",
     "paths": {
       "*": ["node_modules/*"],


### PR DESCRIPTION
* auth middleware 추가
  * 헤더의 authorization에 담긴 JWT 유효성 검사 및 디코드
  * 해당하는 유저 찾기
  * req.user에 유저 정보 담기
  | 관리자 페이지 생성할 때, 관리자 인증 절차 추가 예정
  | 현재는 해당 유저의 정보가 필요한 (댓글, 좋아요, 마이페이지)등을 위해 유저 인증 절차만을 가짐

* Express의 interface Request에 user 타입 추가
  * namespace 사용, 글로벌로 Express의 Request Interface에 user 추가
  * 다른 방법이 생길 경우 변경