### PR TITLE
refactor: data list 반환 타입 수정, user results router 생성

### DIFF
--- a/src/routes/comments.ts
+++ b/src/routes/comments.ts
@@ -64,7 +64,7 @@ router.get(
         totalCount,
         totalPage,
         currentPage: pageNum,
-        comments,
+        data: comments,
       });
     } catch (error) {
       next(error);

--- a/src/routes/contents.ts
+++ b/src/routes/contents.ts
@@ -95,7 +95,7 @@ router.get(
         totalCount,
         totalPage,
         currentPage: pageNum,
-        contents: filteredContent,
+        data: filteredContent,
       });
     } catch (error) {
       next(error);


### PR DESCRIPTION
- 페이징 반환 타입 data로 통일
``` ts
res.status(200).json({
  totalCount,
  totalPage,
  currentPage: pageNum,
  data: results,  // 기존은 contents , comments 등으로 사용
});
```

- user Results router 생성