### PR TITLE
 feat: add get user api 

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import likes from './routes/likes';
 import results from './routes/results';
 import shares from './routes/shares';
 import uploade from './routes/uploade';
+import user from './routes/user';
 import swaggerFile from './swagger/swagger-output.json' assert { type: 'json' };
 
 const app = express();
@@ -39,6 +40,7 @@ app.use('/api/v1/results', results);
 app.use('/api/v1/comments', comments);
 app.use('/api/v1/likes', likes);
 app.use('/api/v1/shares', shares);
+app.use('/api/v1/user', user);
 
 app.use('/api/oauth2/kakao', kakao);
 app.use('/api/v1/upload', uploade);

--- a/src/routes/contents.ts
+++ b/src/routes/contents.ts
@@ -35,7 +35,6 @@ router.post(
       }
 
       const newContent = await new ContentModel<IContent>({
-        // imageUrl: imageUrls[0],
         questions,
         creator: user?.sub,
         ...contents,
@@ -120,9 +119,18 @@ router.get('/:contentId', async (req: Request<{ contentId: string }>, res: Respo
   try {
     const { contentId } = req.params;
 
-    const content = await ContentModel.findById(contentId).exec();
+    const content = await ContentModel.findById(contentId).populate<{ creator: { name: string } }>('creator').exec();
 
-    res.status(200).json(content);
+    if (!content) {
+      return res.status(404).json({ message: 'Content not found' });
+    }
+
+    const modifiedContent = {
+      ...content.toObject(),
+      creator: content.creator.name,
+    };
+
+    res.status(200).json(modifiedContent);
   } catch (error) {
     next(error);
   }

--- a/src/routes/kakao.ts
+++ b/src/routes/kakao.ts
@@ -71,16 +71,10 @@ router.get(
         userId: user._id,
       });
 
-      const userInfo: Pick<IUser, 'name' | 'thumbnail' | 'createdAt'> = {
-        name: user.name,
-        thumbnail: user.thumbnail,
-        createdAt: user.createdAt,
-      };
-
       const token = JwtService.createJWT(user, accessToken);
 
       res.setHeader('Authorization', `Bearer ${token}`);
-      res.status(200).json(userInfo);
+      res.status(200).json({ message: 'Login successful' });
     } catch (error) {
       console.error('Error during Kakao OAuth process:', error);
       if (axios.isAxiosError(error)) {

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,0 +1,20 @@
+import express, { Request, Response, NextFunction } from 'express';
+
+import { tokenChecker } from '../middlewares';
+import UserModel from '../schemas/User';
+
+const router = express.Router();
+
+router.get('/', tokenChecker, async (req: Request, res: Response, next: NextFunction) => {
+  // #swagger.tags = ['Content']
+  try {
+    const user = req.user;
+    const userInfo = await UserModel.findById(user?.sub).exec();
+
+    res.status(200).json(userInfo);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/src/utils/jwtService.ts
+++ b/src/utils/jwtService.ts
@@ -13,9 +13,6 @@ export default class JwtService {
         sub: user._id,
         role: user.role,
         accessToken,
-        name: user.name,
-        thumbnail: user.thumbnail,
-        createdAt: user.createdAt,
       },
       SECRET_KEY,
       {


### PR DESCRIPTION
### getUser API
- 유저 정보 get api 추가 
- 토큰에서 유저 정보 삭제 : id, role 정보만 유지
- 로그인 성공시 반환되던 유저 정보 삭제

### Content - creator
- creator : user id -> user name이 반환되도록 변경

토큰에서 유저정보를 계속 가지고있는 것은 보안상 안 좋다고 생각
유저정보가 필요할때, token 인증 후 유저 정보를 반환할 수 있도록 수정